### PR TITLE
Update python support & add CI/CD on github actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,100 @@
+name: CI_CD
+
+on: [push, pull_request]
+
+permissions: {}
+jobs:
+  Unit_tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+          "2.7",
+          "3.7", "3.8", "3.9", "3.10", "3.11-dev",
+          "pypy-2.7", "pypy-3.8"
+        ]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -r test-requirements.txt -r requirements.txt
+    - name: Run tests
+      run: |
+        pytest
+
+  Integration_tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    needs: Unit_tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+          "3.10",
+        ]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -r test-requirements.txt -r requirements.txt
+    - name: Run tests
+      env:
+        TINIFY_KEY: ${{ secrets.TINIFY_KEY }}
+      run: |
+        pytest test/integration.py
+
+  Publish:
+    if: |
+       github.repository == 'tinify/tinify-python' &&
+       startsWith(github.ref, 'refs/tags') &&
+       github.event_name == 'push'
+    timeout-minutes: 10
+    needs: [Unit_tests, Integration_tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install build wheel
+    - name: Build package (sdist & wheel)
+      run: |
+        python -m build --sdist --wheel --outdir dist/
+    - name: Test sdist install
+      run: |
+        python -m venv sdist_env
+        ./sdist_env/bin/pip install dist/tinify*.tar.gz
+    - name: Test wheel install
+      run: |
+        python -m venv wheel_env
+        ./wheel_env/bin/pip install dist/tinify*.whl
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_ACCESS_TOKEN }}
+        # Use the test repository for testing the publish feature
+        # repository_url: https://test.pypi.org/legacy/
+        packages_dir: dist/
+        print_hash: true
+    

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ pip install -r requirements.txt -r test-requirements.txt
 nosetests
 ```
 
+To test more runtimes, tox can be used
+
+```
+tox
+```
+
+
+
 ### Integration tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-[<img src="https://travis-ci.org/tinify/tinify-python.svg?branch=master" alt="Build Status">](https://travis-ci.org/tinify/tinify-python)
+[![MIT License](http://img.shields.io/badge/license-MIT-green.svg) ](https://github.com/tinify/tinify-python/blob/main/LICENSE)
+[![CI](https://github.com/tinify/tinify-python/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tinify/tinify-python/actions/workflows/run-tests.yml)
+![PyPI](https://img.shields.io/pypi/v/tinify)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tinify)
+![PyPI - Wheel](https://img.shields.io/pypi/wheel/tinify)
+
 
 # Tinify API client for Python
 
@@ -29,7 +34,7 @@ tinify.from_file('unoptimized.png').to_file('optimized.png')
 
 ```
 pip install -r requirements.txt -r test-requirements.txt
-nosetests
+py.test
 ```
 
 To test more runtimes, tox can be used
@@ -44,7 +49,7 @@ tox
 
 ```
 pip install -r requirements.txt -r test-requirements.txt
-TINIFY_KEY=$YOUR_API_KEY nosetests test/integration.py
+TINIFY_KEY=$YOUR_API_KEY py.test test/integration.py
 ```
 
 ## License

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     author_email='info@tinify.com',
     license='MIT',
     long_description='Python client for the Tinify API. Tinify compresses your images intelligently. Read more at https://tinify.com.',
+    long_description_content_type='text/markdown',
     url='https://tinify.com/developers',
 
     packages=['tinify'],
@@ -46,8 +47,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'
-        'Programming Language :: Python :: 3.6'
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,14 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'tinify'))
 from version import __version__
 
 install_require = ['requests >= 2.7.0, < 3.0.0']
-tests_require = ['nose >= 1.3, < 2.0', 'httpretty >= 0.8.10, < 1.0.0']
+tests_require = ['pytest', 'httpretty < 1.1.5']
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')

--- a/test/helper.py
+++ b/test/helper.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
 import json
 import sys
 import os
@@ -55,3 +56,18 @@ class TestHelper(unittest.TestCase):
     @property
     def request(self):
         return httpretty.last_request()
+
+
+
+@contextmanager
+def create_named_tmpfile():
+    #  Due to NamedTemporaryFile requiring to be closed when used on Windows
+    #   we create our own NamedTemporaryFile contextmanager
+    # See note: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
+
+    tmp = NamedTemporaryFile(delete=False)
+    try:
+        tmp.close()
+        yield tmp.name
+    finally:
+        os.unlink(tmp.name)

--- a/test/helper.py
+++ b/test/helper.py
@@ -5,7 +5,6 @@ import json
 import sys
 import os
 import httpretty
-from nose.exc import SkipTest
 
 if sys.version_info < (3, 3):
     from mock import DEFAULT

--- a/test/integration.py
+++ b/test/integration.py
@@ -1,4 +1,5 @@
 import sys, os
+from test.helper import create_named_tmpfile
 
 if not os.environ.get("TINIFY_KEY"):
     sys.exit("Set the TINIFY_KEY environment variable.")
@@ -13,11 +14,13 @@ class ClientIntegrationTest(unittest.TestCase):
     optimized = tinify.from_file(unoptimized_path)
 
     def test_should_compress_from_file(self):
-        with tempfile.NamedTemporaryFile() as tmp:
-            self.optimized.to_file(tmp.name)
+        with create_named_tmpfile() as tmp:
+            self.optimized.to_file(tmp)
 
-            size = os.path.getsize(tmp.name)
-            contents = tmp.read()
+            size = os.path.getsize(tmp)
+
+            with open(tmp, 'rb') as f:
+                contents = f.read()
 
             self.assertTrue(1000 < size < 1500)
 
@@ -27,11 +30,12 @@ class ClientIntegrationTest(unittest.TestCase):
 
     def test_should_compress_from_url(self):
         source = tinify.from_url('https://raw.githubusercontent.com/tinify/tinify-python/master/test/examples/voormedia.png')
-        with tempfile.NamedTemporaryFile() as tmp:
-            source.to_file(tmp.name)
+        with create_named_tmpfile() as tmp:
+            source.to_file(tmp)
 
-            size = os.path.getsize(tmp.name)
-            contents = tmp.read()
+            size = os.path.getsize(tmp)
+            with open(tmp, 'rb') as f:
+                contents = f.read()
 
             self.assertTrue(1000 < size < 1500)
 
@@ -40,11 +44,12 @@ class ClientIntegrationTest(unittest.TestCase):
             self.assertNotIn(b'Copyright Voormedia', contents)
 
     def test_should_resize(self):
-        with tempfile.NamedTemporaryFile() as tmp:
-            self.optimized.resize(method="fit", width=50, height=20).to_file(tmp.name)
+        with create_named_tmpfile() as tmp:
+            self.optimized.resize(method="fit", width=50, height=20).to_file(tmp)
 
-            size = os.path.getsize(tmp.name)
-            contents = tmp.read()
+            size = os.path.getsize(tmp)
+            with open(tmp, 'rb') as f:
+                contents = f.read()
 
             self.assertTrue(500 < size < 1000)
 
@@ -53,11 +58,12 @@ class ClientIntegrationTest(unittest.TestCase):
             self.assertNotIn(b'Copyright Voormedia', contents)
 
     def test_should_preserve_metadata(self):
-        with tempfile.NamedTemporaryFile() as tmp:
-            self.optimized.preserve("copyright", "creation").to_file(tmp.name)
+        with create_named_tmpfile() as tmp:
+            self.optimized.preserve("copyright", "creation").to_file(tmp)
 
-            size = os.path.getsize(tmp.name)
-            contents = tmp.read()
+            size = os.path.getsize(tmp)
+            with open(tmp, 'rb') as f:
+                contents = f.read()
 
             self.assertTrue(1000 < size < 2000)
 

--- a/test/integration.py
+++ b/test/integration.py
@@ -1,10 +1,23 @@
 import sys, os
-from test.helper import create_named_tmpfile
+from contextlib import contextmanager
+import tinify, unittest, tempfile
 
 if not os.environ.get("TINIFY_KEY"):
     sys.exit("Set the TINIFY_KEY environment variable.")
 
-import tinify, unittest, tempfile
+@contextmanager
+def create_named_tmpfile():
+    #  Due to NamedTemporaryFile requiring to be closed when used on Windows
+    #   we create our own NamedTemporaryFile contextmanager
+    # See note: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        tmp.close()
+        yield tmp.name
+    finally:
+        os.unlink(tmp.name)
+
 
 class ClientIntegrationTest(unittest.TestCase):
     tinify.key = os.environ.get("TINIFY_KEY")

--- a/test/tinify_client_test.py
+++ b/test/tinify_client_test.py
@@ -165,9 +165,8 @@ class TinifyClientRequestWithBadServerResponseRepeatedly(TestHelper):
 
         with self.assertRaises(ServerError) as context:
             Client('key').request('GET', '/')
-
-        msg = r'Error while parsing response: .* \(HTTP 543/ParseError\)'
-        self.assertRegexpMatches(str(context.exception), msg)
+            msg = r'Error while parsing response: .* \(HTTP 543/ParseError\)'
+            self.assertRegex(str(context.exception), msg)
 
 class TinifyClientRequestWithBadServerResponseOnce(TestHelper):
     def test_should_issue_request(self):

--- a/test/tinify_client_test.py
+++ b/test/tinify_client_test.py
@@ -7,6 +7,7 @@ from base64 import b64encode
 import tinify
 from tinify import Client, AccountError, ClientError, ConnectionError, ServerError
 import requests
+import pytest
 
 from helper import *
 
@@ -75,10 +76,9 @@ class TinifyClientRequestWhenValidWithProxy(TestHelper):
           'compression-count': 12
         })
 
+    @pytest.mark.skip(reason="https://github.com/gabrielfalcao/HTTPretty/issues/122")
     def test_should_issue_request_with_proxy_authorization(self):
-        raise SkipTest('https://github.com/gabrielfalcao/HTTPretty/issues/122')
         Client('key', None, 'http://user:pass@localhost:8080').request('GET', '/')
-
         self.assertEqual(self.request.headers['proxy-authorization'], 'Basic dXNlcjpwYXNz')
 
 class TinifyClientRequestWithTimeoutRepeatedly(TestHelper):

--- a/test/tinify_source_test.py
+++ b/test/tinify_source_test.py
@@ -147,6 +147,7 @@ class TinifySourceWithValidApiKey(TestHelper):
             self.assertEqual(b'compressed file', tmp.read())
 
     def test_to_file_with_file_object_should_store_image_data(self):
-        with tempfile.NamedTemporaryFile() as tmp:
-            Source.from_buffer('png file').to_file(tmp.name)
-            self.assertEqual(b'compressed file', tmp.read())
+        with create_named_tmpfile() as name:
+            Source.from_buffer('png file').to_file(name)
+            with open(name, 'rb') as f:
+                self.assertEqual(b'compressed file', f.read())

--- a/test/tinify_test.py
+++ b/test/tinify_test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from base64 import b64encode
 
 import tinify
+import pytest
 from helper import *
 
 class TinifyKey(TestHelper):
@@ -27,13 +28,14 @@ class TinifyAppIdentifier(TestHelper):
         self.assertEqual(self.request.headers['user-agent'], tinify.Client.USER_AGENT + " MyApp/2.0")
 
 class TinifyProxy(TestHelper):
+
+    @pytest.mark.skip(reason="https://github.com/gabrielfalcao/HTTPretty/issues/122")
     def test_should_reset_client_with_new_proxy(self):
         httpretty.register_uri(httpretty.CONNECT, 'http://localhost:8080')
         tinify.key = 'abcde'
         tinify.proxy = 'http://localhost:8080'
         tinify.get_client()
         tinify.proxy = 'http://localhost:8080'
-        raise SkipTest('https://github.com/gabrielfalcao/HTTPretty/issues/122')
         tinify.get_client().request('GET', '/')
         self.assertEqual(self.request.headers['user-agent'], tinify.Client.USER_AGENT + " MyApp/2.0")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py36,py37,py38,py39,py310,py311,pypy2,pypy3
+
+[testenv]
+deps = -rtest-requirements.txt
+       -rrequirements.txt
+commands =
+    pytest {posargs}


### PR DESCRIPTION
* Added support to test multiple python versions using the tox runner
* Use pytest instead of nose for wide python support without hoops
* Updated dependencies
* Some deprecated test functions replaced
* Tests are now working on Windows OS
* Add support for newer python versions, and dropped deprecated versions (except 2.7)
* Added badges to the README for project status
* Github actions workflow for testing, building and releasing